### PR TITLE
Improved offline resiliency, updated task dependencies, and language optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /.gradle/
 /.idea/
+/bin/
 /build/
 *.iml
 .DS_Store
+.classpath
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Repository for the Contrast Gradle plugin. This plugin will allow for a Contrast
 | serviceKey  | True     |         | Service Key found in Organization Settings              |
 | apiKey      | True     |         | Api Key found in Organization Settings                  |
 | orgUuid     | True     |         | Organization Uuid found in Organization Settings        |
-| appId       | True     |         | Application Id of application                           |
+| appName     | False    |         | Application name                                        |
 | apiUrl      | True     |         | API Url to your TeamServer instance                     |
-| serverName  | True     |         | Name of server you set with -Dcontrast.server           |
+| serverName  | False    |         | Name of server you set with -Dcontrast.server           |
 | minSeverity | False    | Medium  | Minimum severity level to verify                        |
 | jarPath     | False    |         | Path to contrast.jar if you already have one downloaded |
 

--- a/src/main/groovy/com/contrastsecurity/ConnectToContrast.groovy
+++ b/src/main/groovy/com/contrastsecurity/ConnectToContrast.groovy
@@ -1,0 +1,28 @@
+package com.contrastsecurity
+
+import com.contrastsecurity.sdk.ContrastSDK
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+
+
+class ConnectToContrast extends DefaultTask {
+
+    @TaskAction
+    def exec() {
+        logger.debug('Connecting to Contrast TeamServer')
+
+        ContrastPluginExtension extension = project.contrastConfiguration
+
+        try {
+            ContrastGradlePlugin.contrastSDK = extension.apiUrl?.trim()
+                ? new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey, extension.apiUrl)
+                : new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey)
+        } catch (IllegalArgumentException e) {
+            throw new GradleException('Unable to connect to TeamServer. Please check your Gradle settings.')
+        }
+
+        logger.debug('Successfully connected to Contrast TeamServer')
+    }
+
+}

--- a/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
+++ b/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
@@ -13,7 +13,7 @@ class ContrastGradlePlugin implements Plugin<Project> {
     static Date verifyDateTime;
     static ContrastSDK contrastSDK;
 
-    private static final String EXTENSION_NAME = "contrastConfiguration"
+    private static final String EXTENSION_NAME = 'contrastConfiguration'
 
     @Override
     public void apply(Project target) {
@@ -23,16 +23,16 @@ class ContrastGradlePlugin implements Plugin<Project> {
 
          target.afterEvaluate {
              contrastSDK = connectToTeamServer()
-             target.task("contrastInstall", type: InstallContrastAgent) {
-                 logger.debug("Successfully authenticated to Teamserver.")
-                 logger.debug("Attempting to install the Java agent.")
+             target.task('contrastInstall', type: InstallContrastAgent) {
+                 logger.debug('Successfully authenticated to Teamserver.')
+                 logger.debug('Attempting to install the Java agent.')
              }
-             target.task("contrastVerify", type: VerifyContrast)
+             target.task('contrastVerify', type: VerifyContrast)
         }
     }
 
     ContrastSDK connectToTeamServer() throws GradleException{
-        logger.debug("Attempting to connect to configured TeamServer...")
+        logger.debug('Attempting to connect to configured TeamServer...')
         try {
             if (!StringUtils.isEmpty(extension.apiUrl)) {
                 return new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey, extension.apiUrl);
@@ -40,7 +40,7 @@ class ContrastGradlePlugin implements Plugin<Project> {
                 return new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey);
             }
         } catch (IllegalArgumentException e) {
-            throw new GradleException("Unable to connect to TeamServer. Please check your Gradle settings.")
+            throw new GradleException('Unable to connect to TeamServer. Please check your Gradle settings.')
         }
 
     }

--- a/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
+++ b/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
@@ -1,51 +1,46 @@
 package com.contrastsecurity
 
 import com.contrastsecurity.sdk.ContrastSDK
-import org.apache.commons.lang.StringUtils
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 
 class ContrastGradlePlugin implements Plugin<Project> {
 
-    static ContrastPluginExtension extension;
-    static Date verifyDateTime;
     static ContrastSDK contrastSDK;
 
     private static final String EXTENSION_NAME = 'contrastConfiguration'
 
     @Override
     public void apply(Project target) {
-         //allows for client to define their settings in their projects build.gradle
-         target.extensions.create(EXTENSION_NAME, ContrastPluginExtension)
-         extension = target.getExtensions().getByName(EXTENSION_NAME) as ContrastPluginExtension;
+        //allows for client to define their settings in their projects build.gradle
+        ContrastPluginExtension extension = target.extensions.create(EXTENSION_NAME, ContrastPluginExtension)
+        extension.appName = target.rootProject.name
+        extension.serverName = InetAddress.localHost.hostName
 
-         target.afterEvaluate {
-             contrastSDK = connectToTeamServer()
-             target.task('contrastInstall', type: InstallContrastAgent) {
-                 logger.debug('Successfully authenticated to Teamserver.')
-                 logger.debug('Attempting to install the Java agent.')
-             }
-             target.task('contrastVerify', type: VerifyContrast)
+        Task contrastLogin = target.tasks.create(name: 'contrastLogin', type: ConnectToContrast)
+
+        Task contrastInstall = target.tasks.create(name: 'contrastInstall', type: InstallContrastAgent) {
+            description = 'Installs a Contrast agent in your working copy.'
         }
-    }
+        
+        Task contrastVerify = target.tasks.create(name: 'contrastVerify', type: VerifyContrast) {
+            dependsOn = [contrastLogin]
+            description = 'Checks for new application vulnerabilities.'
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
+        }
 
-    ContrastSDK connectToTeamServer() throws GradleException{
-        logger.debug('Attempting to connect to configured TeamServer...')
-        try {
-            if (!StringUtils.isEmpty(extension.apiUrl)) {
-                return new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey, extension.apiUrl);
-            } else {
-                return new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey);
+        target.afterEvaluate {
+            if (!extension.jarPath?.trim()) {
+                Task contrastDownload = target.tasks.create(name: 'contrastDownload', type: DownloadContrastAgent) {
+                    dependsOn = [contrastLogin]
+                    description = 'Downloads the latest version of the Contrast agent.'
+                }
+                extension.jarPath = contrastDownload.agentFile.absolutePath
+                contrastInstall.dependsOn = [contrastDownload]
             }
-        } catch (IllegalArgumentException e) {
-            throw new GradleException('Unable to connect to TeamServer. Please check your Gradle settings.')
         }
-
     }
 }
-
-
-
-

--- a/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
+++ b/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
@@ -24,14 +24,15 @@ class ContrastGradlePlugin implements Plugin<Project> {
          target.afterEvaluate {
              contrastSDK = connectToTeamServer()
              target.task("contrastInstall", type: InstallContrastAgent) {
-                 println "Successfully authenticated to Teamserver. \n Attempting to install the Java agent."
+                 logger.debug("Successfully authenticated to Teamserver.")
+                 logger.debug("Attempting to install the Java agent.")
              }
              target.task("contrastVerify", type: VerifyContrast)
         }
     }
 
     ContrastSDK connectToTeamServer() throws GradleException{
-        println "Attempting to connect to configured TeamServer..."
+        logger.debug("Attempting to connect to configured TeamServer...")
         try {
             if (!StringUtils.isEmpty(extension.apiUrl)) {
                 return new ContrastSDK(extension.username, extension.serviceKey, extension.apiKey, extension.apiUrl);

--- a/src/main/groovy/com/contrastsecurity/ContrastPluginExtension.groovy
+++ b/src/main/groovy/com/contrastsecurity/ContrastPluginExtension.groovy
@@ -9,7 +9,7 @@ class ContrastPluginExtension {
     String orgUuid
     String appName
     String serverName
-    String minSeverity = "Medium" //default
+    String minSeverity = 'Medium' //default
     String jarPath
     
 }

--- a/src/main/groovy/com/contrastsecurity/DownloadContrastAgent.groovy
+++ b/src/main/groovy/com/contrastsecurity/DownloadContrastAgent.groovy
@@ -1,0 +1,38 @@
+package com.contrastsecurity
+
+import com.contrastsecurity.models.AgentType
+import com.contrastsecurity.sdk.ContrastSDK
+import org.apache.commons.io.FileUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.api.tasks.TaskAction
+
+
+class DownloadContrastAgent extends DefaultTask {
+
+    final File agentFile = new File(project.buildDir, 'contrast.jar')
+
+    DownloadContrastAgent() {
+        // TODO Add a check to make sure the JAR is up to date???
+        outputs.upToDateWhen{
+            agentFile.exists()
+        }
+    }
+
+    @TaskAction
+    def exec () {
+        logger.debug('Downloading latest Contrast agent')
+
+        ContrastSDK contrast = ContrastGradlePlugin.contrastSDK
+        ContrastPluginExtension extension = project.contrastConfiguration
+
+        try {
+            byte[] javaAgent = contrast.getAgent(AgentType.JAVA, extension.orgUuid)
+            FileUtils.writeByteArrayToFile(agentFile, javaAgent)
+            logger.debug("Saved Contrast agent to ${agentFile.absolutePath}")
+        } catch (IOException e) {
+            logger.warn("Unable to save Contrast agent to ${agentFile.absolutePath} (${e.class.name}: ${e.message})")
+            throw new StopExecutionException('Unable to download the latest java agent')
+        }
+    }
+}

--- a/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
+++ b/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
@@ -1,69 +1,26 @@
 package com.contrastsecurity
 
-import com.contrastsecurity.exceptions.UnauthorizedException
-import com.contrastsecurity.models.AgentType
-import com.contrastsecurity.sdk.ContrastSDK
-import org.apache.commons.io.FileUtils
-import org.apache.commons.lang.StringUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.Project
+import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 
 
 class InstallContrastAgent extends DefaultTask {
 
-    private static final String AGENT_NAME = 'contrast.jar'
-    private ContrastPluginExtension extension
+    boolean ignoreFailures
 
     @TaskAction
     def exec () {
-        extension = ContrastGradlePlugin.extension;
-        installJavaAgent(this.getProject(), ContrastGradlePlugin.contrastSDK)
-        ContrastGradlePlugin.verifyDateTime = new Date()
-    }
+        ContrastPluginExtension extension = project.contrastConfiguration
 
-
-    private File installJavaAgent(Project project, ContrastSDK connection) {
-        byte[] javaAgent
-        File agentFile
-
-        if (StringUtils.isEmpty(extension.jarPath)) {
-            logger.debug('No jar path was configured.  Downloading the latest contrast.jar...')
-            try {
-                javaAgent = connection.getAgent(AgentType.JAVA, extension.orgUuid);
-            } catch (IOException e) {
-                throw new GradleException('Unable to download the latest java agent.')
-            } catch (UnauthorizedException e) {
-                throw new GradleException('Unable to retrieve the latest java agent due to authorization.')
-            }
-
-            // Save the jar to the 'build' directory
-            agentFile = new File(project.getBuildDir().toString() + File.separator + AGENT_NAME)
-
-            try {
-                FileUtils.writeByteArrayToFile(agentFile, javaAgent);
-            } catch (IOException e) {
-                throw new GradleException('Unable to save the latest java agent.')
-            }
-
-            logger.debug("Saved the latest java agent to ${agentFile.absolutePath}")
-
+        File agentFile = new File(extension.jarPath)
+        if (agentFile.exists()) {
+            logger.debug("Loaded Java agent from ${extension.jarPath}")
+        } else if (ignoreFailures) {
+            throw new StopExecutionException("Unable to load Java agent from ${extension.jarPath}")
         } else {
-            logger.debug("Using configured jar path ${extension.jarPath}")
-            agentFile = new File(extension.jarPath)
-
-            if (!agentFile.exists()) {
-                throw new GradleException("Unable to load the local Java agent from ${extension.jarPath}")
-            }
-            logger.debug("Loaded the latest java agent from ${extension.jarPath}")
-
+            throw new GradleException("Unable to load Java agent from ${extension.jarPath}")
         }
-
-        return agentFile;
     }
-
-
-
 }
-

--- a/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
+++ b/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
@@ -29,7 +29,7 @@ class InstallContrastAgent extends DefaultTask {
         File agentFile
 
         if (StringUtils.isEmpty(extension.jarPath)) {
-            println "No jar path was configured.  Downloading the latest contrast.jar..."
+            logger.debug("No jar path was configured.  Downloading the latest contrast.jar...")
             try {
                 javaAgent = connection.getAgent(AgentType.JAVA, extension.orgUuid);
             } catch (IOException e) {
@@ -47,16 +47,16 @@ class InstallContrastAgent extends DefaultTask {
                 throw new GradleException("Unable to save the latest java agent.")
             }
 
-            println "Saved the latest java agent to " + agentFile.getAbsolutePath()
+            logger.debug("Saved the latest java agent to " + agentFile.getAbsolutePath())
 
         } else {
-            println "Using configured jar path " + extension.jarPath
+            logger.debug("Using configured jar path ${extension.jarPath}")
             agentFile = new File(extension.jarPath)
 
             if (!agentFile.exists()) {
-                throw new GradleException("Unable to load the local Java agent from " + extension.jarPath)
+                throw new GradleException("Unable to load the local Java agent from ${extension.jarPath}")
             }
-            println ("Loaded the latest java agent from " + extension.jarPath)
+            logger.debug("Loaded the latest java agent from ${extension.jarPath}")
 
         }
 

--- a/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
+++ b/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.TaskAction
 
 class InstallContrastAgent extends DefaultTask {
 
-    private static final String AGENT_NAME = "contrast.jar"
+    private static final String AGENT_NAME = 'contrast.jar'
     private ContrastPluginExtension extension
 
     @TaskAction
@@ -29,13 +29,13 @@ class InstallContrastAgent extends DefaultTask {
         File agentFile
 
         if (StringUtils.isEmpty(extension.jarPath)) {
-            logger.debug("No jar path was configured.  Downloading the latest contrast.jar...")
+            logger.debug('No jar path was configured.  Downloading the latest contrast.jar...')
             try {
                 javaAgent = connection.getAgent(AgentType.JAVA, extension.orgUuid);
             } catch (IOException e) {
-                throw new GradleException("Unable to download the latest java agent.")
+                throw new GradleException('Unable to download the latest java agent.')
             } catch (UnauthorizedException e) {
-                throw new GradleException("Unable to retrieve the latest java agent due to authorization.")
+                throw new GradleException('Unable to retrieve the latest java agent due to authorization.')
             }
 
             // Save the jar to the 'build' directory
@@ -44,10 +44,10 @@ class InstallContrastAgent extends DefaultTask {
             try {
                 FileUtils.writeByteArrayToFile(agentFile, javaAgent);
             } catch (IOException e) {
-                throw new GradleException("Unable to save the latest java agent.")
+                throw new GradleException('Unable to save the latest java agent.')
             }
 
-            logger.debug("Saved the latest java agent to " + agentFile.getAbsolutePath())
+            logger.debug("Saved the latest java agent to ${agentFile.absolutePath}")
 
         } else {
             logger.debug("Using configured jar path ${extension.jarPath}")

--- a/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
+++ b/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
@@ -30,7 +30,7 @@ class VerifyContrast extends DefaultTask {
     }
 
     public void verifyForVulnerabilities() {
-        println "Checking for new vulnerabilities..."
+        logger.debug("Checking for new vulnerabilities...")
 
         String applicationId = getApplicationId(contrast, extension.appName)
 
@@ -41,7 +41,7 @@ class VerifyContrast extends DefaultTask {
         form.setStartDate(ContrastGradlePlugin.verifyDateTime)
         form.setServerIds(Arrays.asList(serverId));
 
-        println("Sending vulnerability request to TeamServer.")
+        logger.debug("Sending vulnerability request to TeamServer.")
 
         Traces traces
 
@@ -54,17 +54,17 @@ class VerifyContrast extends DefaultTask {
         }
 
         if (traces != null && traces.getCount() > 0) {
-            println(traces.getCount() + " new vulnerability(s) were found! Printing vulnerability report.")
+            logger.debug(traces.getCount() + " new vulnerability(s) were found! Printing vulnerability report.")
             for (Trace trace : traces.getTraces()) {
-                println(generateTraceReport(trace))
+                logger.debug(generateTraceReport(trace))
             }
 
             throw new GradleException("Your application is vulnerable. Please see the above report for new vulnerabilities.")
         } else {
-            println("No new vulnerabilities were found!")
+            logger.debug("No new vulnerabilities were found!")
         }
 
-        println("Finished verifying your application.")
+        logger.debug("Finished verifying your application.")
     }
 
     /** Retrieves the server id by server name

--- a/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
+++ b/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
@@ -30,7 +30,7 @@ class VerifyContrast extends DefaultTask {
     }
 
     public void verifyForVulnerabilities() {
-        logger.debug("Checking for new vulnerabilities...")
+        logger.debug('Checking for new vulnerabilities...')
 
         String applicationId = getApplicationId(contrast, extension.appName)
 
@@ -41,30 +41,30 @@ class VerifyContrast extends DefaultTask {
         form.setStartDate(ContrastGradlePlugin.verifyDateTime)
         form.setServerIds(Arrays.asList(serverId));
 
-        logger.debug("Sending vulnerability request to TeamServer.")
+        logger.debug('Sending vulnerability request to TeamServer.')
 
         Traces traces
 
         try {
             traces = contrast.getTraces(extension.orgUuid, applicationId, form);
         } catch (IOException e) {
-            throw new GradleException("Unable to retrieve the traces.", e)
+            throw new GradleException('Unable to retrieve the traces.', e)
         } catch (UnauthorizedException e) {
-            throw new GradleException("Unable to connect to TeamServer.", e)
+            throw new GradleException('Unable to connect to TeamServer.', e)
         }
 
         if (traces != null && traces.getCount() > 0) {
-            logger.debug(traces.getCount() + " new vulnerability(s) were found! Printing vulnerability report.")
+            logger.debug("${traces.count} new vulnerability(s) were found! Printing vulnerability report.")
             for (Trace trace : traces.getTraces()) {
                 logger.debug(generateTraceReport(trace))
             }
 
-            throw new GradleException("Your application is vulnerable. Please see the above report for new vulnerabilities.")
+            throw new GradleException('Your application is vulnerable. Please see the above report for new vulnerabilities.')
         } else {
-            logger.debug("No new vulnerabilities were found!")
+            logger.debug('No new vulnerabilities were found!')
         }
 
-        logger.debug("Finished verifying your application.")
+        logger.debug('Finished verifying your application.')
     }
 
     /** Retrieves the server id by server name
@@ -85,15 +85,15 @@ class VerifyContrast extends DefaultTask {
         try {
             servers = sdk.getServersWithFilter(extension.orgUuid, serverFilterForm)
         } catch (IOException e) {
-            throw new GradleException("Unable to retrieve the servers.", e)
+            throw new GradleException('Unable to retrieve the servers.', e)
         } catch (UnauthorizedException e) {
-            throw new GradleException("Unable to connect to TeamServer.", e)
+            throw new GradleException('Unable to connect to TeamServer.', e)
         }
 
         if (!servers.getServers().isEmpty()) {
             serverId = servers.getServers().get(0).getServerId()
         } else {
-            throw new GradleException("Server with name '" + extension.serverName + "' not found.")
+            throw new GradleException("Server with name '${extension.serverName}' not found.")
         }
 
         return serverId
@@ -113,9 +113,9 @@ class VerifyContrast extends DefaultTask {
         try {
             applications = sdk.getApplications(extension.orgUuid)
         } catch (IOException e) {
-            throw new GradleException("Unable to retrieve the applications.", e)
+            throw new GradleException('Unable to retrieve the applications.', e)
         } catch (UnauthorizedException e) {
-            throw new GradleException("Unable to connect to TeamServer.", e)
+            throw new GradleException('Unable to connect to TeamServer.', e)
         }
 
         for (Application application : applications.getApplications()) {
@@ -124,7 +124,7 @@ class VerifyContrast extends DefaultTask {
             }
         }
 
-        throw new GradleException("Application with name '" + applicationName + "' not found.")
+        throw new GradleException("Application with name '${applicationName}' not found.")
     }
 
     /**
@@ -134,16 +134,10 @@ class VerifyContrast extends DefaultTask {
      */
     private String generateTraceReport(Trace trace) {
         StringBuilder sb = new StringBuilder()
-        sb.append("Trace: ")
-        sb.append(trace.getTitle())
-        sb.append("\nTrace Uuid: ")
-        sb.append(trace.getUuid())
-        sb.append("\nTrace Severity: ")
-        sb.append(trace.getSeverity())
-        sb.append("\nTrace Likelihood: ")
-        sb.append(trace.getLikelihood())
-        sb.append("\n")
-
+        sb.append("Trace: ${trace.title}${System.lineSeparator()}")
+        sb.append("Trace Uuid: ${trace.uuid}${System.lineSeparator()}")
+        sb.append("Trace Severity: ${trace.severity}${System.lineSeparator()}")
+        sb.append("Trace Likelihood: ${trace.likelihood}${System.lineSeparator()}")
         return sb.toString()
     }
 
@@ -157,21 +151,18 @@ class VerifyContrast extends DefaultTask {
 
         List<RuleSeverity> ruleSeverities = new ArrayList<RuleSeverity>();
         switch(severity){
-            case "Note":
+            case 'Note':
                 ruleSeverities.add(RuleSeverity.NOTE);
-            case "Low":
+            case 'Low':
                 ruleSeverities.add(RuleSeverity.LOW);
-            case "Medium":
+            case 'Medium':
                 ruleSeverities.add(RuleSeverity.MEDIUM);
-            case "High":
+            case 'High':
                 ruleSeverities.add(RuleSeverity.HIGH);
-            case "Critical":
+            case 'Critical':
                 ruleSeverities.add(RuleSeverity.CRITICAL);
         }
 
         return EnumSet.copyOf(ruleSeverities);
     }
-
-    // Severity levels
-    private static final List<String> SEVERITIES = Arrays.asList("Note", "Low", "Medium", "High", "Critical")
 }

--- a/src/test/groovy/com/contrastsecurity/ContrastTaskTests.groovy
+++ b/src/test/groovy/com/contrastsecurity/ContrastTaskTests.groovy
@@ -1,8 +1,6 @@
 package com.contrastsecurity
 
 import com.contrastsecurity.http.RuleSeverity
-import com.google.common.base.Verify
-import org.apache.maven.execution.BuildFailure
 import org.gradle.BuildResult
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder


### PR DESCRIPTION
This pull request blends a couple of different improvements:

1. Enable lazy login process to TeamServer by moving the login process to its own task and chaining other tasks (downloading an agent, verifying results) accordingly.
> The current Gradle plugin attempts to log in to TeamServer at the beginning of every build. As a result, this requires a developer to be online and able to connect to TeamServer in order to run *_any_* task.

2. Move all of the task declarations out of the `afterEvaluate` block to easy task chaining between custom build file tasks and Contrast plugin tasks
> The primary driver of this was to support integration with other plugins, such as Spring Boot. As of 1.1.1, a top-level statement of `bootRun.dependsOn contrastInstall` will fail.

3. Set default values to extension properties where appropriate.
> The `appName` and `serverName` variables can use runtime attributes as reasonable defaults. Given that these were required configuration variables before, implementing new de facto defaults provides backwards compatibility.

4. Replaced `println` statements with calls to Gradle logging to support quieter output.

5. Miscellaneous low-level improvements (e.g. replaced double quotes where temptable strings were not necessary)

NOTE: I see that HEAD declares version 1.1.0, but 1.1.1 has already been published. Apologies if this PR creates any conflicts against the latest-and-greates working copy on someone's workstation.

