### PR TITLE
Use build number instead of timestamp to check for vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     compile localGroovy()
     compile gradleApi()
-    compile group: "com.contrastsecurity", name: "contrast-sdk-java", version:"2.2"
+    compile group: "com.contrastsecurity", name: "contrast-sdk-java", version:"2.7"
 
     testCompile gradleTestKit()
     testCompile group: "junit", name: "junit", version: "4.11"

--- a/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
+++ b/src/main/groovy/com/contrastsecurity/ContrastGradlePlugin.groovy
@@ -10,6 +10,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 class ContrastGradlePlugin implements Plugin<Project> {
 
     static ContrastSDK contrastSDK;
+    static String appVersionQualifier;
 
     private static final String EXTENSION_NAME = 'contrastConfiguration'
 

--- a/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
+++ b/src/main/groovy/com/contrastsecurity/InstallContrastAgent.groovy
@@ -5,13 +5,17 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 
+import java.text.SimpleDateFormat
+
 
 class InstallContrastAgent extends DefaultTask {
 
     boolean ignoreFailures
 
     @TaskAction
-    def exec () {
+    def exec() {
+        ContrastGradlePlugin.appVersionQualifier = new SimpleDateFormat("yyyyMMddHHmm").format(new Date())
+
         ContrastPluginExtension extension = project.contrastConfiguration
 
         File agentFile = new File(extension.jarPath)

--- a/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
+++ b/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
@@ -10,8 +10,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
-import java.text.SimpleDateFormat
-
 class VerifyContrast extends DefaultTask {
 
     @TaskAction
@@ -20,10 +18,6 @@ class VerifyContrast extends DefaultTask {
 
         ContrastSDK contrast = ContrastGradlePlugin.contrastSDK
         ContrastPluginExtension extension = project.contrastConfiguration
-
-        if (!ContrastGradlePlugin.appVersionQualifier) {
-            ContrastGradlePlugin.appVersionQualifier = new SimpleDateFormat("yyyyMMddHHmm").format(new Date())
-        }
 
         String applicationId = getApplicationId(contrast, extension.orgUuid, extension.appName)
 

--- a/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
+++ b/src/main/groovy/com/contrastsecurity/VerifyContrast.groovy
@@ -4,20 +4,15 @@ import com.contrastsecurity.exceptions.UnauthorizedException
 import com.contrastsecurity.http.RuleSeverity
 import com.contrastsecurity.http.ServerFilterForm
 import com.contrastsecurity.http.TraceFilterForm
-import com.contrastsecurity.models.Application
-import com.contrastsecurity.models.Applications
-import com.contrastsecurity.models.Servers
-import com.contrastsecurity.models.Trace
-import com.contrastsecurity.models.Traces
+import com.contrastsecurity.models.*
 import com.contrastsecurity.sdk.ContrastSDK
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 
+import java.text.SimpleDateFormat
 
 class VerifyContrast extends DefaultTask {
-
-    Date startDate = new Date();
 
     @TaskAction
     def exec() {
@@ -26,13 +21,17 @@ class VerifyContrast extends DefaultTask {
         ContrastSDK contrast = ContrastGradlePlugin.contrastSDK
         ContrastPluginExtension extension = project.contrastConfiguration
 
+        if (!ContrastGradlePlugin.appVersionQualifier) {
+            ContrastGradlePlugin.appVersionQualifier = new SimpleDateFormat("yyyyMMddHHmm").format(new Date())
+        }
+
         String applicationId = getApplicationId(contrast, extension.orgUuid, extension.appName)
 
         long serverId = getServerId(contrast, extension.orgUuid, applicationId, extension.serverName)
 
         TraceFilterForm form = new TraceFilterForm();
         form.setSeverities(getSeverityList(extension.minSeverity))
-        form.setStartDate(startDate)
+        form.setAppVersionTags(Collections.singletonList(getAppVersion(extension.appName, ContrastGradlePlugin.appVersionQualifier)))
         form.setServerIds(Arrays.asList(serverId));
 
         logger.debug('Requesting vulnerability report from TeamServer')
@@ -145,7 +144,7 @@ class VerifyContrast extends DefaultTask {
     public static EnumSet<RuleSeverity> getSeverityList(String severity) {
 
         List<RuleSeverity> ruleSeverities = new ArrayList<RuleSeverity>();
-        switch(severity) {
+        switch (severity) {
             case 'Note':
                 ruleSeverities.add(RuleSeverity.NOTE);
             case 'Low':
@@ -159,5 +158,9 @@ class VerifyContrast extends DefaultTask {
         }
 
         return EnumSet.copyOf(ruleSeverities);
+    }
+
+    private String getAppVersion(String appName, String appVersionQualifier) {
+        return appName + "-" + appVersionQualifier;
     }
 }


### PR DESCRIPTION
Updated the java sdk dependency to have support for appVersionTags filtering.
appVersionQualifier variable is initialized during the contrastInstall task. In case the contrastInstall task has not been run, the variable is initialized in the contrastVerify task.
Testing can be done by setting up the sample gradle app as described in the readme. Publish gradle plugin to maven local, then change the contrast gradle plugin dependency in the sample app to "1.4.0-SNAPSHOT"